### PR TITLE
Update vendorsetup.sh

### DIFF
--- a/vendorsetup.sh
+++ b/vendorsetup.sh
@@ -1,4 +1,4 @@
-for combo in $(curl -s https://raw.githubusercontent.com/CyanogenMod/hudson/master/cm-build-targets | sed -e 's/#.*$//' | grep cm-12.0 | awk {'print $1'})
-do
-    add_lunch_combo $combo
-done
+#for combo in $(curl -s https://raw.githubusercontent.com/CyanogenMod/hudson/master/cm-build-targets | sed -e 's/#.*$//' | grep cm-12.0 | awk {'print $1'})
+#do
+#    add_lunch_combo $combo
+#done


### PR DESCRIPTION
WHY????
113 items in my lunch menu -_-
Why not just add RR supported devices, or let each device trees vendorsetup.sh do the needful, let this be blank
