### PR TITLE
separate unofficial and official versions

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -244,7 +244,12 @@ PRODUCT_PROPERTY_OVERRIDES += \
 DEVICE_PACKAGE_OVERLAYS += vendor/cm/overlay/common
 
 PRODUCT_VERSION = 5.7.1
-    CM_VERSION := ResurrectionRemix-M-v$(PRODUCT_VERSION)-$(shell date -u +%Y%m%d)-$(CM_BUILD)
+ifeq ($(RR_RELEASE), OFFICIAL)    
+    CM_VERSION := RR-M-v$(PRODUCT_VERSION)-$(shell date -u +%Y%m%d)-$(CM_BUILD)-OFFICIAL
+else
+    CM_VERSION := RR-M-v$(PRODUCT_VERSION)-$(shell date -u +%Y%m%d)-$(CM_BUILD)-UNOFFICIAL
+endif
+
 
 PRODUCT_PROPERTY_OVERRIDES += \
   ro.rr.version=$(CM_VERSION) \


### PR DESCRIPTION
Just proposition of my concept, shorten name because it would be too long. This needs RR_RELEASE define in cm.mk for official devices. I think that type of release should be clearly showed, if you think that this isn't looks so good then we could include release type in separate section in about phone.
