### PR TITLE
vendor: Remove unnecessary launcher packages

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -176,10 +176,8 @@ PRODUCT_PACKAGES += \
 
 # Custom CM packages
 PRODUCT_PACKAGES += \
-    Launcher3 \
     ResurrectionOTA \
     ResurrectionStats \
-    Trebuchet \
     MusicFX \
     CMFileManager \
     Eleven \


### PR DESCRIPTION
 * We use prebuilt Google Pixel Launcher,
   so let's use it as default.

Change-Id: I47821925a313d9dc46d27a85f6637efc14bb8c8d