### PR TITLE
vendor: changelog allow export of days_to_log

### DIFF
--- a/tools/changelog.sh
+++ b/tools/changelog.sh
@@ -26,7 +26,10 @@ echo ""
 echo -e ${cya}" 〉Generating $source_name Changelog..\n"${txtrst}
 echo ${ylw}" ▼ For how many days changelog do you want to generate?"${txtrst}
 echo ""
+# use 'export days_to_log=5' before '. build/envsetup.sh' were 5 is days to log
+if [ -z $days_to_log ];then
 read -r -t 60 days_to_log || days_to_log=7
+fi
 echo >> $Changelog;
 echo " ▼ $source_name Ver 5.8.0 Changelog"    >> $Changelog;
 echo '' >> $Changelog;


### PR DESCRIPTION
use 'export days_to_log=5' before '. build/envsetup.sh' were 5 is days you wanna to log

Signed-off-by: Felipe Leon <fglfgl27@gmail.com>

conversation about this change in the below commit

https://github.com/ResurrectionRemix/android_vendor_resurrection/commit/a80c0f0ba886197f16085ae394234e0db0671aa4