### PR TITLE
vendor: changelog.sh avoid update version number in changelog

### DIFF
--- a/tools/changelog.sh
+++ b/tools/changelog.sh
@@ -30,8 +30,9 @@ echo ""
 if [ -z $days_to_log ];then
 read -r -t 60 days_to_log || days_to_log=7
 fi
+version=$(grep -r 'PRODUCT_VERSION ' vendor/cm/config/ | sed 's/vendor\/cm\/config\/common.mk:PRODUCT_VERSION //g' | sed  's/= //g');
 echo >> $Changelog;
-echo " ▼ $source_name Ver 5.8.0 Changelog"    >> $Changelog;
+echo " ▼ $source_name Ver $version Changelog"    >> $Changelog;
 echo '' >> $Changelog;
 echo >> $Changelog;
 


### PR DESCRIPTION
Double sed necessary to avoid the print of the line that contains 'PRODUCT_VERSION ='
That will be printed if used in terminal and in the CHANGELOG.mkdn

Signed-off-by: Felipe Leon <fglfgl27@gmail.com>