### PR TITLE
vendor: fix changelog incompatibility with rr variant

### DIFF
--- a/tools/changelog.sh
+++ b/tools/changelog.sh
@@ -3,9 +3,9 @@
 # like this:
 # https://github.com/bhb27/android_vendor_crdroid/blob/change_temp/Changelog.md
 # file.md can work with more data or have more lines then a page wiki
-. $ANDROID_BUILD_TOP/vendor/cm/tools/colors
 # input variables set the below the rest must be automatic
 source_tree="$ANDROID_BUILD_TOP"; #path here must be inside home directory
+. $source_tree/vendor/cm/tools/colors
 changelog_path_name=CHANGELOG.mkdn #changelog file path/name.extension
 source_name="Resurrection Remix Nougat" #Name to display in changelog.md top before version
 # input variables end


### PR DESCRIPTION
There is no colors and I'm getting some error after . build/envsetup.sh
this solves it

Signed-off-by: Felipe Leon <fglfgl27@gmail.com>

the error was...

	./vendor/cm/tools/changelog.sh: line 6: /vendor/cm/tools/colors: No such file or directory
	touch: cannot touch ‘/CHANGELOG.mkdn’: Permission denied

	 ▼ For how many days changelog do you want to generate?

	 〉30/sec Time-out (7 days)

	 ▼ Type a number

	./vendor/cm/tools/changelog.sh: line 36: /CHANGELOG.mkdn: Permission denied
	./vendor/cm/tools/changelog.sh: line 37: /CHANGELOG.mkdn: Permission denied
	./vendor/cm/tools/changelog.sh: line 38: /CHANGELOG.mkdn: Permission denied
	./vendor/cm/tools/changelog.sh: line 39: /CHANGELOG.mkdn: Permission denied

	 〉Generating day number:1 12/21/2016..
	error: command 'forall' requires repo to be installed first.
		 Use "repo init" to install it here.
	sed: can't read /CHANGELOG.mkdn: No such file or directory

	 √ Changelog successfully generated.

