### PR TITLE
Fix RR properties for splitted vendor devices

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -320,6 +320,16 @@ PRODUCT_PROPERTY_OVERRIDES += \
     rr.build.type=$(RR_BUILDTYPE) \
     rr.ota.version= $(shell date +%Y%m%d) \
     ro.rr.tag=$(shell grep "refs/tags" .repo/manifest.xml  | cut -d'"' -f2 | cut -d'/' -f3)
+   
+# Properties for splitted vendor devices
+PRODUCT_GENERIC_PROPERTIES += \
+    ro.rr.version=$(RR_VERSION) \
+    ro.rr.releasetype=$(RR_BUILDTYPE) \
+    ro.rr.build.version=$(PRODUCT_VERSION_MAJOR).$(PRODUCT_VERSION_MINOR) \
+    ro.modversion=$(RR_VERSION) \
+    rr.build.type=$(RR_BUILDTYPE) \
+    rr.ota.version= $(shell date +%Y%m%d) \
+    ro.rr.tag=$(shell grep "refs/tags" .repo/manifest.xml  | cut -d'"' -f2 | cut -d'/' -f3)   
     
 PRODUCT_EXTRA_RECOVERY_KEYS += \
     vendor/rr/build/target/product/security/rr


### PR DESCRIPTION
This commit fixes like "ERROR: couldn't find ro.rr.version in build.prop" errors.