### PR TITLE
overlay: Set default assistant component name to Google

### DIFF
--- a/overlay/common/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/common/frameworks/base/core/res/res/values/config.xml
@@ -102,4 +102,6 @@
     <string-array name="config_ephemeralResolverPackage">
         <item>com.google.android.gms</item>
     </string-array>
+    <!-- Component name for default assistant on this device -->
+    <string name="config_defaultAssistantComponentName">com.google.android.googlequicksearchbox/com.google.android.voiceinteraction.GsaVoiceInteractionService</string>
 </resources>


### PR DESCRIPTION
Change-Id: I569b9a51e3c54196ca20910084d662c4d268d712

 Conflicts:
	overlay/common/frameworks/base/core/res/res/values/config.xml