### PR TITLE
lineage: Rework DTBO image generation

### DIFF
--- a/build/tasks/dtbo.mk
+++ b/build/tasks/dtbo.mk
@@ -3,13 +3,13 @@ ifeq ($(strip $(BOARD_KERNEL_SEPARATED_DTBO)),true)
 
 MKDTIMG := $(HOST_OUT_EXECUTABLES)/mkdtimg$(HOST_EXECUTABLE_SUFFIX)
 
-INSTALLED_DTBOIMAGE_TARGET := $(PRODUCT_OUT)/dtbo.img
+BOARD_PREBUILT_DTBOIMAGE := $(PRODUCT_OUT)/dtbo-pre.img
 
 # Most specific paths must come first in possible_dtbo_dirs
 possible_dtbo_dirs = $(KERNEL_OUT)/arch/$(KERNEL_ARCH)/boot/dts $(KERNEL_OUT)/arch/arm/boot/dts
 
 define build-dtboimage-target
-    $(call pretty,"Target dtbo image: $(INSTALLED_DTBOIMAGE_TARGET)")
+    $(call pretty,"Target dtbo image: $(BOARD_PREBUILT_DTBOIMAGE)")
     $(hide) for dir in $(possible_dtbo_dirs); do \
                 if [ -d "$$dir" ]; then \
                     dtbo_dir="$$dir"; \
@@ -20,18 +20,8 @@ define build-dtboimage-target
     $(hide) chmod a+r $@
 endef
 
-ifeq ($(BOARD_AVB_ENABLE),true)
-$(INSTALLED_DTBOIMAGE_TARGET): $(AVBTOOL) $(BOARD_AVB_DTBO_KEY_PATH) $(MKDTIMG) $(INSTALLED_KERNEL_TARGET)
+$(BOARD_PREBUILT_DTBOIMAGE): $(MKDTIMG) $(INSTALLED_KERNEL_TARGET)
 	$(build-dtboimage-target)
-	$(AVBTOOL) add_hash_footer \
-		--image $@ \
-		--partition_size $(BOARD_DTBOIMG_PARTITION_SIZE) \
-		--partition_name dtbo $(INTERNAL_AVB_DTBO_SIGNING_ARGS) \
-		$(BOARD_AVB_DTBO_ADD_HASH_FOOTER_ARGS)
-else
-$(INSTALLED_DTBOIMAGE_TARGET): $(MKDTIMG) $(INSTALLED_KERNEL_TARGET)
-	$(build-dtboimage-target)
-endif
 
 endif # BOARD_KERNEL_SEPARATED_DTBO
 endif # TARGET_NO_KERNEL

--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -276,16 +276,13 @@ alldefconfig:
 	env KCONFIG_NOTIMESTAMP=true \
 		 $(call make-kernel-target,alldefconfig)
 
-TARGET_PREBUILT_DTBO = $(PRODUCT_OUT)/dtbo/arch/$(KERNEL_ARCH)/boot/dtbo.img
-$(TARGET_PREBUILT_DTBO): $(AVBTOOL)
+ifeq ($(TARGET_NEEDS_DTBOIMAGE),true)
+BOARD_PREBUILT_DTBOIMAGE = $(PRODUCT_OUT)/dtbo/arch/$(KERNEL_ARCH)/boot/dtbo.img
+$(BOARD_PREBUILT_DTBOIMAGE):
 	echo -e ${CL_GRN}"Building DTBO.img"${CL_RST}
 	$(call make-dtbo-target,$(KERNEL_DEFCONFIG))
 	$(call make-dtbo-target,dtbo.img)
-	$(AVBTOOL) add_hash_footer \
-		--image $@ \
-		--partition_size $(BOARD_DTBOIMG_PARTITION_SIZE) \
-		--partition_name dtbo $(INTERNAL_AVB_DTBO_SIGNING_ARGS) \
-		$(BOARD_AVB_DTBO_ADD_HASH_FOOTER_ARGS)
+endif # TARGET_NEEDS_DTBOIMAGE
 
 endif # FULL_KERNEL_BUILD
 
@@ -300,19 +297,13 @@ $(file) : $(KERNEL_BIN) | $(ACP)
 ALL_PREBUILT += $(INSTALLED_KERNEL_TARGET)
 endif
 
-ifeq ($(TARGET_NEEDS_DTBOIMAGE),true)
-file := $(INSTALLED_DTBOIMAGE_TARGET)
-ALL_PREBUILT += $(file)
-$(file) : $(TARGET_PREBUILT_DTBO) | $(ACP)
-	$(transform-prebuilt-to-target)
-
+INSTALLED_DTBOIMAGE_TARGET := $(PRODUCT_OUT)/dtbo.img
 ALL_PREBUILT += $(INSTALLED_DTBOIMAGE_TARGET)
-endif
 
 .PHONY: kernel
 kernel: $(INSTALLED_KERNEL_TARGET)
 
-.PHONY: dtbo
-dtbo: $(INSTALLED_DTBOIMAGE_TARGET)
+.PHONY: dtboimage
+dtboimage: $(INSTALLED_DTBOIMAGE_TARGET)
 
 endif # TARGET_NO_KERNEL

--- a/config/BoardConfigKernel.mk
+++ b/config/BoardConfigKernel.mk
@@ -112,3 +112,10 @@ ifeq ($(HOST_OS),darwin)
   KERNEL_MAKE_FLAGS += C_INCLUDE_PATH=$(BUILD_TOP)/external/elfutils/libelf:/usr/local/opt/openssl/include
   KERNEL_MAKE_FLAGS += LIBRARY_PATH=/usr/local/opt/openssl/lib
 endif
+
+# Set DTBO image locations so the build system knows to build them
+ifeq ($(TARGET_NEEDS_DTBOIMAGE),true)
+BOARD_PREBUILT_DTBOIMAGE ?= $(PRODUCT_OUT)/dtbo/arch/$(KERNEL_ARCH)/boot/dtbo.img
+else ifeq ($(BOARD_KERNEL_SEPARATED_DTBO),true)
+BOARD_PREBUILT_DTBOIMAGE ?= $(PRODUCT_OUT)/dtbo-pre.img
+endif


### PR DESCRIPTION
Currently we handle the DTBO images from start to finish, including
AVB footers, and just drop them in $(PRODUCT_OUT)/dtbo.img when done.
While this works for the most part, we are limited in what we can do
with the DTBO images. For example non-A/B device recovery images must
have a copy of the DTBO image appended to recovery (see AOSP docs:
https://source.android.com/devices/bootloader/recovery-image ). This
means that we need to pass the pre-AVB dtbo image into
BOARD_PREBUILT_DTBOIMAGE in order to let the AOSP build system handle it.

This commit reworks the way the DTBO images are built, placing them at
$(PRODUCT_OUT)/dtbo-pre.img instead and setting BOARD_PREBUILT_DTBOIMAGE
to that path so the AOSP build system can pick the images up and sign
them and append to recovery (for applicable devices).

Change-Id: I8819d7cd92ba298de67dbc7f6b321917ba8524f1