### PR TITLE
 qcom: Add UM 4.14 platforms &  vendor: Add audio/include/uapi to include path 

### DIFF
--- a/build/core/vendor/qcom_boards.mk
+++ b/build/core/vendor/qcom_boards.mk
@@ -1,6 +1,10 @@
 # Board platforms lists to be used for
 # TARGET_BOARD_PLATFORM specific featurization
 
+# Platform name variables - used in makefiles everywhere
+MSMSTEPPE := sm6150
+TRINKET := trinket #SM6125
+
 # A Family
 QCOM_BOARD_PLATFORMS += msm7x27a
 QCOM_BOARD_PLATFORMS += msm7x30
@@ -35,6 +39,10 @@ QCOM_BOARD_PLATFORMS += sdm660
 
 QCOM_BOARD_PLATFORMS += sdm710
 QCOM_BOARD_PLATFORMS += sdm845
+
+QCOM_BOARD_PLATFORMS += $(TRINKET)
+QCOM_BOARD_PLATFORMS += $(MSMSTEPPE)
+QCOM_BOARD_PLATFORMS += msmnile sm8150
 
 # MSM7000 Family
 MSM7K_BOARD_PLATFORMS := msm7x30

--- a/build/soong/Android.bp
+++ b/build/soong/Android.bp
@@ -31,7 +31,7 @@ lineage_generator {
     cmd: "make $(KERNEL_MAKE_FLAGS) -C $(TARGET_KERNEL_SOURCE) O=$(genDir) ARCH=$(KERNEL_ARCH) $(KERNEL_CROSS_COMPILE) headers_install",
 
     // Directories that can be imported by a cc_* module generated_headers property
-    export_include_dirs: ["usr/include", "usr/techpack/audio/include"],
+    export_include_dirs: ["usr/include", "usr/techpack/audio/include", "usr/audio/include/uapi"],
 
     // Sources for dependency tracking
     dep_root: "$(TARGET_KERNEL_SOURCE)",

--- a/config/BoardConfigQcom.mk
+++ b/config/BoardConfigQcom.mk
@@ -4,7 +4,8 @@ BR_FAMILY := msm8909 msm8916
 UM_3_18_FAMILY := msm8937 msm8953 msm8996
 UM_4_4_FAMILY := msm8998 sdm660
 UM_4_9_FAMILY := sdm845 sdm710
-UM_PLATFORMS := $(UM_3_18_FAMILY) $(UM_4_4_FAMILY) $(UM_4_9_FAMILY)
+UM_4_14_FAMILY := msmnile sm8150 $(MSMSTEPPE) $(TRINKET)
+UM_PLATFORMS := $(UM_3_18_FAMILY) $(UM_4_4_FAMILY) $(UM_4_9_FAMILY) $(UM_4_14_FAMILY)
 
 BOARD_USES_ADRENO := true
 
@@ -36,7 +37,7 @@ ifneq ($(filter $(UM_PLATFORMS),$(TARGET_BOARD_PLATFORM)),)
 endif
 
 # Enable DRM PP driver on UM platforms that support it
-ifeq ($(call is-board-platform-in-list, $(UM_4_9_FAMILY)),true)
+ifeq ($(call is-board-platform-in-list, $(UM_4_9_FAMILY) $(UM_4_14_FAMILY)),true)
     TARGET_USES_DRM_PP := true
 endif
 
@@ -45,12 +46,12 @@ TARGET_ADDITIONAL_GRALLOC_10_USAGE_BITS ?= 0
 TARGET_ADDITIONAL_GRALLOC_10_USAGE_BITS += | (1 << 21)
 
 # Mark GRALLOC_USAGE_PRIVATE_10BIT_TP as valid gralloc bits on UM platforms that support it
-ifeq ($(call is-board-platform-in-list, $(UM_4_9_FAMILY)),true)
+ifeq ($(call is-board-platform-in-list, $(UM_4_9_FAMILY) $(UM_4_14_FAMILY)),true)
     TARGET_ADDITIONAL_GRALLOC_10_USAGE_BITS += | (1 << 27)
 endif
 
 # List of targets that use master side content protection
-MASTER_SIDE_CP_TARGET_LIST := msm8996 msm8998 sdm660 sdm845
+MASTER_SIDE_CP_TARGET_LIST := msm8996 $(UM_4_4_FAMILY) $(UM_4_9_FAMILY) $(UM_4_14_FAMILY)
 
 ifneq ($(filter $(B_FAMILY),$(TARGET_BOARD_PLATFORM)),)
     MSM_VIDC_TARGET_LIST := $(B_FAMILY)
@@ -70,6 +71,9 @@ else ifneq ($(filter $(UM_4_4_FAMILY),$(TARGET_BOARD_PLATFORM)),)
 else ifneq ($(filter $(UM_4_9_FAMILY),$(TARGET_BOARD_PLATFORM)),)
     MSM_VIDC_TARGET_LIST := $(UM_4_9_FAMILY)
     QCOM_HARDWARE_VARIANT := sdm845
+else ifneq ($(filter $(UM_4_14_FAMILY),$(TARGET_BOARD_PLATFORM)),)
+    MSM_VIDC_TARGET_LIST := $(UM_4_14_FAMILY)
+    QCOM_HARDWARE_VARIANT := sm8150
 else
     MSM_VIDC_TARGET_LIST := $(TARGET_BOARD_PLATFORM)
     QCOM_HARDWARE_VARIANT := $(TARGET_BOARD_PLATFORM)


### PR DESCRIPTION
* 1st for to fix hals detection bcz violet uses sm8150 respectively
* 2nd for fixing 8150 audio hals issue