### PR TITLE
Update privapp-permissions-lineage.xml

### DIFF
--- a/config/permissions/privapp-permissions-lineage.xml
+++ b/config/permissions/privapp-permissions-lineage.xml
@@ -38,8 +38,17 @@
     </privapp-permissions>
 
     <!-- Additional permissions on top of privapp-permissions-platform.xml -->
+    <privapp-permissions package="com.android.settings">
+        <permission name="android.permission.ACCESS_FONT_MANAGER"/>
+        <permission name="android.permission.NAVIGATION_EDITOR"/>
+    </privapp-permissions>
+     
+    <!-- Additional permissions on top of privapp-permissions-platform.xml -->
     <privapp-permissions package="com.android.systemui">
+        <permission name="android.permission.FORCE_STOP_PACKAGES"/>
         <permission name="android.permission.MODIFY_DAY_NIGHT_MODE"/>
+        <permission name="android.permission.NAVIGATION_EDITOR"/>
+        <permission name="android.permission.PACKAGE_USAGE_STATS"/>
     </privapp-permissions>
 
     <privapp-permissions package="org.lineageos.audiofx">

--- a/config/permissions/privapp-permissions-lineage.xml
+++ b/config/permissions/privapp-permissions-lineage.xml
@@ -109,5 +109,9 @@
         <permission name="android.permission.REBOOT"/>
         <permission name="android.permission.RECOVERY"/>
     </privapp-permissions>
+     
+    <privapp-permissions package="org.omnirom.omnistyle">
+        <permission name="android.permission.CHANGE_OVERLAY_PACKAGES"/>
+    </privapp-permissions>
 
 </permissions>


### PR DESCRIPTION
Update to fix fatal error during boot process:

java.lang.IllegalStateException: Signature|privileged permissions not in privapp-permissions whitelist: {com.android.systemui: android.permission.NAVIGATION_EDITOR, org.omnirom.omnistyle: android.permission.CHANGE_OVERLAY_PACKAGES, com.android.systemui: android.permission.PACKAGE_USAGE_STATS, com.android.settings: android.permission.ACCESS_FONT_MANAGER, com.android.settings: android.permission.NAVIGATION_EDITOR, com.android.systemui: android.permission.FORCE_STOP_PACKAGES, com.android.launcher3: android.permission.STATUS_BAR}