### PR TITLE
Do not enforce but log priv-app permission whitelist

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -97,7 +97,7 @@ PRODUCT_COPY_FILES += \
 
 # Enforce privapp-permissions whitelist
 PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
-    ro.control_privapp_permissions=enforce
+    ro.control_privapp_permissions=log
 
 # Hidden API whitelist
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
To prevent devices from not booting until all priv-app permissions from either ROM side or device side have been resolved.

- Users should check logcat for any denied priv-app permissions for the eventual re-enforcing of the permissions.